### PR TITLE
Updated chat link to discord from slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ Nothing to do with
 https://www.amazon.com/Event-Centric-Simplicity-Addison-Wesley-Signature/dp/0321768221
 
 Have a look at the issues.   
-They are mainly collected from recurring discussions & questions in the [DDD-CQRS-ES slack](https://j.mp/ddd-es-cqrs)
+They are mainly collected from recurring discussions & questions in the [DDD-CQRS-ES discord]([https://j.mp/ddd-es-cqrs](https://discord.gg/3Nv3FAQ2))


### PR DESCRIPTION
Changed Slack link to Discord: https://discord.gg/3Nv3FAQ2 invite and changed text to reference discord not slack.